### PR TITLE
Only update tail job id if no error is encountered

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -210,11 +210,6 @@ func (e *Exporter) scrapeJobs() error {
 
 	reachedLastTail := false
 	tailJobID := ""
-	defer func() {
-		if tailJobID != "" {
-			e.lastTailJobID = tailJobID
-		}
-	}()
 
 	notSeen := mergeJobMap(e.startingJobs, e.runningJobs)
 
@@ -295,6 +290,11 @@ func (e *Exporter) scrapeJobs() error {
 			delete(e.startingJobs, jobID)
 		}
 		e.m.jobsCompleted.WithLabelValues(stateDeleted, job.Pipeline.Name).Inc()
+	}
+
+	// Only update tail job id if we finished without an error.
+	if tailJobID != "" {
+		e.lastTailJobID = tailJobID
 	}
 
 	return nil


### PR DESCRIPTION
If an error is encountered in the middle of processing the stream (e.g. due to a timeout), the tail job id is erroneously updated, and jobs are left behind.